### PR TITLE
support handshake in NoiseStream trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ name = "kv"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes 1.0.1",
  "dashmap",
  "futures",

--- a/live_coding/kv/Cargo.toml
+++ b/live_coding/kv/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = "0.2"
 tokio-util = { version = "0.6", features = ["codec"] }
 futures = "0.3"
 snow = "0.8"
+async-trait = "0.1"
 
 [build-dependencies]
 prost-build = "0.7"

--- a/live_coding/kv/src/server.rs
+++ b/live_coding/kv/src/server.rs
@@ -50,19 +50,7 @@ async fn main() -> Result<()> {
 
         tokio::spawn(async move {
             let mut stream = NoiseCodec::builder(NOISE_PARAMS, false).new_framed(stream)?;
-            // <- e
-            let data = stream.next().await.unwrap()?;
-            info!("<- e");
-
-            // -> e, ee, s, es
-            stream.send(data.freeze()).await?;
-            info!("-> e, ee, s, es");
-
-            // <- s, se
-            let _data = stream.next().await.unwrap()?;
-            info!("<- s, se");
-
-            stream.into_transport_mode()?;
+            stream.handshake().await?;
 
             while let Some(Ok(buf)) = stream.next().await {
                 let msg: Request = buf.try_into()?;


### PR DESCRIPTION
Yesterday when I tried to put `handshake` into `NoiseStream` trait, as handshake is an asyn func, I introduced async-trait and moved the code to do handshake in client/server to the impl of the `handshake` function. However, the code can't be compiled due to "`S` cannot be unpinned" (4:27:08 in my rust training video 2). At that time I thought I have to use `Pin` and probably pin_project, which would take much longer time to work on (I was already 1.5 hours behind schedule), so I gave it up and continue. 

However if I spent a little more time I could see that `TcpStream` is `Unpin` (see: https://docs.rs/tokio/1.7.1/tokio/net/struct.TcpStream.html#impl-Unpin), which means that I just need to put `Unpin` as the trait bound for `S` as this:

```rust
impl<S> NoiseStream for Framed<S, NoiseCodec>
where
    S: AsyncRead + AsyncWrite + Send + Sync + Unpin
```

And problem solved.